### PR TITLE
fnページ：実行結果表がモバイルだと見づらいのでリストに変更

### DIFF
--- a/src/components/fn/FunctionReturnPattern.astro
+++ b/src/components/fn/FunctionReturnPattern.astro
@@ -1,6 +1,6 @@
 ---
 import { type FnReturn } from "../../content/config"
-import { Table, TableBody, TableBodyCell, TableBodyRow } from "flowbite-svelte"
+import ReturnArrow from "@/icons/fluent/arrow-curve-up-right-20-regular.astro"
 
 interface Props {
   patterns: FnReturn[]
@@ -9,15 +9,16 @@ interface Props {
 const { patterns } = Astro.props
 ---
 
-<Table>
-  <TableBody>
-    {
-      patterns.map((pattern) => (
-        <TableBodyRow class="border-none">
-          <TableBodyCell class="text-inherit py-2 font-normal">{pattern.if}</TableBodyCell>
-          <TableBodyCell class="text-inherit py-2 font-normal">{pattern.summary}</TableBodyCell>
-        </TableBodyRow>
-      ))
-    }
-  </TableBody>
-</Table>
+<ul class="list-disc px-6 leading-loose">
+  {
+    patterns.map((pattern) => (
+      <li class="pb-2 last:pb-0">
+        <div class="py-2 text-sm leading-relaxed">{pattern.if}</div>
+        <div class="inline-flex items-baseline gap-2">
+          <ReturnArrow svgClass="rotate-90 relative top-1" />
+          <span class="leading-loose">{pattern.summary}</span>
+        </div>
+      </li>
+    ))
+  }
+</ul>

--- a/src/components/fn/FunctionReturnPattern.astro
+++ b/src/components/fn/FunctionReturnPattern.astro
@@ -16,7 +16,7 @@ const { patterns } = Astro.props
         <div class="py-2 text-sm leading-relaxed">{pattern.if}</div>
         <div class="inline-flex items-baseline gap-2">
           <ReturnArrow svgClass="rotate-90 relative top-1" />
-          <span class="leading-loose">{pattern.summary}</span>
+          {pattern.summary}
         </div>
       </li>
     ))

--- a/src/components/fn/FunctionReturnValue.astro
+++ b/src/components/fn/FunctionReturnValue.astro
@@ -1,5 +1,6 @@
 ---
 import { type FnReturn } from "../../content/config"
+import ReturnArrow from "@/icons/fluent/arrow-curve-up-right-20-regular.astro"
 
 interface Props {
   value: Omit<FnReturn, "if">
@@ -8,6 +9,7 @@ interface Props {
 const { value } = Astro.props
 ---
 
-<div class="px-6 text-sm">
+<div class="px-5 leading-loose inline-flex items-baseline gap-2">
+  <ReturnArrow svgClass="rotate-90 relative top-1" />
   {value.summary}
 </div>

--- a/src/icons/fluent/arrow-curve-up-right-20-regular.astro
+++ b/src/icons/fluent/arrow-curve-up-right-20-regular.astro
@@ -1,0 +1,21 @@
+---
+interface Props {
+  svgClass?: string
+}
+
+const { svgClass } = Astro.props
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="1em"
+  height="1em"
+  viewBox="6 2 9 16"
+  class={svgClass}
+>
+  <path
+    fill="currentColor"
+    d="M14.146 6.854a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 1 0 .708.708L10 3.707V10c0 1.965-.247 3.38-.764 4.473c-.512 1.08-1.308 1.887-2.493 2.598a.5.5 0 0 0 .514.858c1.315-.79 2.269-1.732 2.882-3.027c.608-1.283.861-2.867.861-4.902V3.707z"
+  >
+  </path>
+</svg>


### PR DESCRIPTION
表だとスクロールが発生して見づらいので、リストに変えた

before 

<img src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/6a7a7a94-607a-415e-b75c-a0abcd8499a8" width="375" />


after

<img src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/e9f5e251-b9e6-4129-ad02-41c3994d9bcc" width="375" />

