### PR TITLE
複数指定可能な引数グループを示すフィールド表記を追加し、同一の引数は同じ色でハイライトするように

### DIFF
--- a/src/components/fn/FunctionArgument.astro
+++ b/src/components/fn/FunctionArgument.astro
@@ -1,5 +1,6 @@
 ---
 import type { FnArgument } from "@/content/config"
+import { getArgColorHues } from "./args"
 
 interface Props {
   args: FnArgument[]
@@ -7,7 +8,7 @@ interface Props {
 
 const { args } = Astro.props
 
-const hues = args.map((_, i) => i * (360 / args.length) + "deg")
+const hues = getArgColorHues(args)
 ---
 
 <div class="grid auto-cols-[minmax(0,max-content)] gap-x-8 gap-y-4 leading-loose text-sm">

--- a/src/components/fn/FunctionSignature.astro
+++ b/src/components/fn/FunctionSignature.astro
@@ -1,5 +1,6 @@
 ---
 import { type FnArgument } from "../../content/config"
+import { getArgColorHues, remapArgs } from "./args"
 
 interface Props {
   name: string
@@ -9,28 +10,8 @@ interface Props {
 
 const { name, args, coloring = false } = Astro.props
 
-const hues = coloring ? args.map((_, i) => i * (360 / args.length) + "deg") : []
-
-const repeatGroup = (() => {
-  const restStartIdx = args.findIndex((arg) => arg.multiple)
-  if (restStartIdx === -1) return []
-
-  const rest = args.slice(restStartIdx)
-  if (rest.length === 0) return []
-
-  return Array.from({ length: 2 }, (_, i) =>
-    rest.map((arg, j) => ({
-      ...arg,
-      summary: `${arg.summary}${i + 1}`,
-      hue: hues[restStartIdx + j]
-    }))
-  )
-})()
-
-const argsList: (FnArgument & { hue: string })[] = [
-  ...args.filter((arg) => !arg.multiple).map((arg, i) => ({ ...arg, hue: hues[i] })),
-  ...repeatGroup.flat()
-]
+const hues = coloring ? getArgColorHues(args) : []
+const { args: showArgs, rest } = remapArgs(args, hues)
 ---
 
 <code class="siguneture text-lg pb-2">
@@ -38,13 +19,13 @@ const argsList: (FnArgument & { hue: string })[] = [
   <span>(</span>
   <div class:list={["arguments", { coloring }]}>
     {
-      argsList.map((arg) => (
+      showArgs.map((arg) => (
         <span class="argument" style={arg.hue ? `--hue: ${arg.hue}` : ""}>
           <span class="summary">{arg.summary}</span>
         </span>
       ))
     }
-    {repeatGroup.length > 0 && <span class="argument">...</span>}
+    {rest && <span class="argument">...</span>}
   </div>
   <div>)</div>
 </code>

--- a/src/components/fn/FunctionSignature.astro
+++ b/src/components/fn/FunctionSignature.astro
@@ -10,6 +10,27 @@ interface Props {
 const { name, args, coloring = false } = Astro.props
 
 const hues = coloring ? args.map((_, i) => i * (360 / args.length) + "deg") : []
+
+const repeatGroup = (() => {
+  const restStartIdx = args.findIndex((arg) => arg.multiple)
+  if (restStartIdx === -1) return []
+
+  const rest = args.slice(restStartIdx)
+  if (rest.length === 0) return []
+
+  return Array.from({ length: 2 }, (_, i) =>
+    rest.map((arg, j) => ({
+      ...arg,
+      summary: `${arg.summary}${i + 1}`,
+      hue: hues[restStartIdx + j]
+    }))
+  )
+})()
+
+const argsList: (FnArgument & { hue: string })[] = [
+  ...args.filter((arg) => !arg.multiple).map((arg, i) => ({ ...arg, hue: hues[i] })),
+  ...repeatGroup.flat()
+]
 ---
 
 <code class="siguneture text-lg pb-2">
@@ -17,12 +38,13 @@ const hues = coloring ? args.map((_, i) => i * (360 / args.length) + "deg") : []
   <span>(</span>
   <div class:list={["arguments", { coloring }]}>
     {
-      args.map((arg, i) => (
-        <span class="argument" style={hues[i] ? `--hue: ${hues[i]}` : ""}>
+      argsList.map((arg) => (
+        <span class="argument" style={arg.hue ? `--hue: ${arg.hue}` : ""}>
           <span class="summary">{arg.summary}</span>
         </span>
       ))
     }
+    {repeatGroup.length > 0 && <span class="argument">...</span>}
   </div>
   <div>)</div>
 </code>

--- a/src/components/fn/args.ts
+++ b/src/components/fn/args.ts
@@ -1,0 +1,45 @@
+import type { FnArgument } from "@/content/config"
+
+interface FnArgumentWithHue extends FnArgument {
+  hue: string
+}
+
+export const getArgColorHues = (args: FnArgument[]) => {
+  return args.map((_, i) => i * (360 / args.length) + "deg")
+}
+
+const getRepeatGroupArgs = (
+  args: FnArgument[],
+  hues: string[]
+): { args: FnArgumentWithHue[]; start: number } => {
+  const fallback = { args: [], start: args.length }
+
+  const restStartIdx = args.findIndex((arg) => arg.multiple)
+  if (restStartIdx === -1) return fallback
+
+  const rest = args.slice(restStartIdx)
+  if (rest.length === 0) return fallback
+
+  const remapped = Array.from({ length: 2 }, (_, i) =>
+    rest.map((arg, j) => ({
+      ...arg,
+      summary: `${arg.summary}${i + 1}`,
+      hue: hues[restStartIdx + j]
+    }))
+  )
+
+  return { args: remapped.flat(), start: restStartIdx }
+}
+
+export const remapArgs = (
+  args: FnArgument[],
+  hues: string[]
+): { args: FnArgumentWithHue[]; rest: boolean } => {
+  const { args: repeatGroupArgs, start } = getRepeatGroupArgs(args, hues)
+  const notRepeatArgs = args.slice(0, start).map((arg, i) => ({ ...arg, hue: hues[i] }))
+
+  return {
+    args: [...notRepeatArgs, ...repeatGroupArgs],
+    rest: repeatGroupArgs.length > 0
+  }
+}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -61,7 +61,8 @@ const zFnArgument = z
           .strict()
       )
       .optional(),
-    detail: z.string().optional()
+    detail: z.string().optional(),
+    multiple: z.boolean().optional()
   })
   .strict()
 

--- a/src/content/fn/COUNTIFS.mdx
+++ b/src/content/fn/COUNTIFS.mdx
@@ -2,11 +2,10 @@
 name: COUNTIFS
 summary: 複数条件をすべて満たすセルの数を数える関数
 args:
-  - summary: 検索範囲1
-  - summary: 条件1
-  - summary: 検索範囲2
-  - summary: 条件2
-  - summary: ...
+  - summary: 検索範囲
+    multiple: true
+  - summary: 条件
+    multiple: true
 return:
   summary: 条件をすべて満たすセルの個数
   type: number

--- a/src/pages/fn/[...slug].astro
+++ b/src/pages/fn/[...slug].astro
@@ -26,9 +26,13 @@ const { Content } = await entry.render()
 const { category } = data
 
 // 引数の詳細を表示する条件
-// - summary以外の詳細フィールドを設定している引数がある
+// - summaryとmultiple以外の詳細フィールドを設定している引数がある
 const isShowArgDetails =
-  data.args.length > 0 && data.args.some((arg) => Object.keys(arg).length > 1)
+  data.args.length > 0 &&
+  data.args.some((arg) => {
+    const count = Object.keys(arg).filter((key) => !["summary", "multiple"].includes(key)).length
+    return count > 0
+  })
 ---
 
 <ArticlePageRoot>


### PR DESCRIPTION
<img width="863" alt="スクリーンショット 2024-03-01 8 34 34" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/3911a436-0944-403d-8f42-7f00c6c24a29">
