### PR TITLE
関数のシグネチャ表示のコンマ位置を調整

### DIFF
--- a/src/components/fn/FunctionSignature.astro
+++ b/src/components/fn/FunctionSignature.astro
@@ -19,13 +19,16 @@ const { args: showArgs, rest } = remapArgs(args, hues)
   <span>(</span>
   <div class:list={["arguments", { coloring }]}>
     {
-      showArgs.map((arg) => (
-        <span class="argument" style={arg.hue ? `--hue: ${arg.hue}` : ""}>
-          <span class="summary">{arg.summary}</span>
-        </span>
+      showArgs.map((arg, i) => (
+        <>
+          <span class="summary" style={arg.hue ? `--hue: ${arg.hue}` : ""}>
+            {arg.summary}
+          </span>
+          {i < showArgs.length - 1 && <span>,&ensp;</span>}
+        </>
       ))
     }
-    {rest && <span class="argument">...</span>}
+    {rest && <span>,&ensp;...</span>}
   </div>
   <div>)</div>
 </code>
@@ -44,11 +47,6 @@ const { args: showArgs, rest } = remapArgs(args, hues)
   }
 
   .arguments {
-    display: contents;
-  }
-
-  .argument:not(:last-child)::after {
-    content: ",";
     display: contents;
   }
 


### PR DESCRIPTION

before
<img width="863" alt="スクリーンショット 2024-03-01 8 34 34" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/e3ac450d-23f2-4a30-8eac-d93042a40a47">

after
<img width="863" alt="スクリーンショット 2024-03-01 17 01 46" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/f77e549d-aabe-49a8-94b9-67d868faa337">
