### PR TITLE
関数解説ポップアップでも引数の色分け表示を有効化

### DIFF
--- a/src/components/fn/FunctionDescription.astro
+++ b/src/components/fn/FunctionDescription.astro
@@ -13,7 +13,7 @@ const { data } = entry
 ---
 
 <div class="flex flex-col gap-4 p-2">
-  <FunctionSignature name={data.name} args={data.args} />
+  <FunctionSignature name={data.name} args={data.args} coloring />
   <p class="text-sm">{data.summary}</p>
   {
     data.return && (


### PR DESCRIPTION
before
<img width="753" alt="スクリーンショット 2024-03-01 17 05 06" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/fb521697-9228-4ef5-82c4-1d8d7319676d">

after
<img width="753" alt="スクリーンショット 2024-03-01 17 05 18" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/3399dbef-8d19-402c-8a55-a4f799971485">