### PR TITLE
見出しの階層ごとにスタイルを当てる

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "flowbite": "^2.3.0",
     "flowbite-svelte": "^0.44.23",
     "handsontable": "^14.1.0",
+    "hast": "^1.0.0",
+    "hast-util-heading-rank": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rehype-pretty-code": "^0.13.0",

--- a/src/components/content/Heading2.astro
+++ b/src/components/content/Heading2.astro
@@ -1,0 +1,11 @@
+<h2>
+  <slot />
+</h2>
+
+<style>
+  h2 {
+    @apply py-2 mb-10 mt-20 text-3xl font-normal border-y border-zinc-300;
+    margin-inline: calc(-1 * var(--body-padding-x));
+    padding-inline-start: var(--body-padding-x);
+  }
+</style>

--- a/src/components/content/Heading3.astro
+++ b/src/components/content/Heading3.astro
@@ -1,0 +1,25 @@
+<h3>
+  <span class="text-justify">
+    <slot />
+  </span>
+</h3>
+
+<style>
+  h3 {
+    @apply my-10 text-2xl font-normal flex items-center;
+    margin-inline-start: calc(-1 * var(--body-padding-x));
+  }
+  h3 > span {
+    max-width: calc(100% - var(--body-padding-x) * 2);
+  }
+  h3::before {
+    @apply block h-px content-[""] bg-zinc-300;
+    width: calc(var(--body-padding-x) - 0.5ch);
+    margin-inline-end: 0.5ch;
+  }
+  h3::after {
+    @apply block h-px content-[""] flex-grow bg-zinc-300;
+    margin-inline-start: 0.5ch;
+    margin-inline-end: calc(-1 * var(--body-padding-x));
+  }
+</style>

--- a/src/components/content/Heading4.astro
+++ b/src/components/content/Heading4.astro
@@ -1,0 +1,11 @@
+<h4>
+  <slot />
+</h4>
+
+<style>
+  h4 {
+    @apply my-10 text-xl font-normal inline-block border-b-[3px] border-double border-zinc-200;
+    margin-inline-start: calc(-0.5 * var(--body-padding-x));
+    padding-inline: calc(0.5 * var(--body-padding-x));
+  }
+</style>

--- a/src/components/content/Heading5.astro
+++ b/src/components/content/Heading5.astro
@@ -1,0 +1,9 @@
+<h5>
+  <slot />
+</h5>
+
+<style>
+  h5 {
+    @apply my-10 text-lg font-normal inline-block border-b-[3px] border-dotted border-zinc-200;
+  }
+</style>

--- a/src/lib/rehype-slug.ts
+++ b/src/lib/rehype-slug.ts
@@ -1,0 +1,32 @@
+import GithubSlugger from "github-slugger"
+import { headingRank } from "hast-util-heading-rank"
+import { toString } from "hast-util-to-string"
+import { visit } from "unist-util-visit"
+
+interface Options {
+  prefix?: string
+}
+
+const emptyOptions: Options = {}
+const slugs = new GithubSlugger()
+
+export default function rehypeSlug(options?: Options) {
+  const settings = options || emptyOptions
+  const prefix = settings.prefix || ""
+
+  return function (tree: import("hast").Root) {
+    slugs.reset()
+
+    visit(tree, "element", function (node) {
+      const depth = headingRank(node)
+      if (!depth) return
+
+      // 除外するもの
+      // - h1タグ
+      // - 既にidが設定されているタグ
+      if (depth > 1 && !node.properties.id) {
+        node.properties.id = prefix + slugs.slug(toString(node).trim())
+      }
+    })
+  }
+}

--- a/src/middleware/heading.ts
+++ b/src/middleware/heading.ts
@@ -1,0 +1,36 @@
+import { unified } from "unified"
+import rehypeParse from "rehype-parse"
+import rehypeStringify from "rehype-stringify"
+import rehypeSlug from "@/lib/rehype-slug"
+import type { MiddlewareHandler } from "astro"
+import { SITE_BASE } from "@/site-config"
+
+const processor = unified().use(rehypeParse).use(rehypeSlug).use(rehypeStringify)
+
+const APPLY_TARGET = ["topic"]
+
+export const addHeadingIds: MiddlewareHandler = async (context, next) => {
+  const response = await next()
+
+  const [category, slug] = context.url.pathname.replace(SITE_BASE, "").split("/").filter(Boolean)
+
+  // 記事ページ以外は処理しない
+  // - category === undefined => top page
+  // - slug === undefined => top page for category
+  if (!category || !slug) {
+    return response
+  }
+
+  // APPLY_TARGET配下のページのみ処理する
+  if (!APPLY_TARGET.includes(category)) {
+    return response
+  }
+
+  const html = await response.text()
+  const processedHtml = (await processor.process(html)).toString()
+
+  return new Response(processedHtml, {
+    status: 200,
+    headers: response.headers
+  })
+}

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,4 @@
+import { sequence } from "astro:middleware"
+import { addHeadingIds } from "./heading"
+
+export const onRequest = sequence(addHeadingIds)

--- a/src/pages/topic/[...slug].astro
+++ b/src/pages/topic/[...slug].astro
@@ -46,14 +46,33 @@ const { category } = data
 
 <style>
   ._content :global(h2) {
-    @apply my-10 text-3xl font-normal;
+    @apply py-2 mb-10 mt-20 text-3xl font-normal border-y border-zinc-300;
+    margin-inline: calc(-1 * var(--body-padding-x));
+    padding-inline-start: var(--body-padding-x);
   }
 
   ._content :global(h3) {
-    @apply my-10 text-2xl font-normal;
+    @apply my-10 text-2xl font-normal flex items-center;
+    margin-inline-start: calc(-1 * var(--body-padding-x));
+  }
+  ._content :global(h3::before) {
+    @apply block h-px content-[""] bg-zinc-300;
+    width: calc(var(--body-padding-x) - 0.5ch);
+    margin-inline-end: 0.5ch;
+  }
+  ._content :global(h3::after) {
+    @apply block h-px content-[""] flex-grow bg-zinc-300;
+    margin-inline-start: 0.5ch;
+    margin-inline-end: calc(-1 * var(--body-padding-x));
   }
 
   ._content :global(h4) {
-    @apply my-10 text-xl font-normal;
+    @apply my-10 text-xl font-normal inline-block border-b-[3px] border-double border-zinc-200;
+    margin-inline-start: calc(-0.5 * var(--body-padding-x));
+    padding-inline: calc(0.5 * var(--body-padding-x));
+  }
+
+  ._content :global(h5) {
+    @apply my-10 text-lg font-normal inline-block border-b-[3px] border-dotted border-zinc-200;
   }
 </style>

--- a/src/pages/topic/[...slug].astro
+++ b/src/pages/topic/[...slug].astro
@@ -5,6 +5,10 @@ import ColorTag from "@/components/tag/ColorTag.astro"
 import Breadcrumb from "@/components/article/Breadcrumb.astro"
 import { Heading, Hr, Li } from "flowbite-svelte"
 import UList from "@/components/content/UList.astro"
+import Heading2 from "@/components/content/Heading2.astro"
+import Heading3 from "@/components/content/Heading3.astro"
+import Heading4 from "@/components/content/Heading4.astro"
+import Heading5 from "@/components/content/Heading5.astro"
 import Toc from "@/components/article/Toc.astro"
 
 export async function getStaticPaths() {
@@ -38,41 +42,10 @@ const { category } = data
       <Hr />
       <Toc headings={headings} />
       <div class="_content">
-        <Content components={{ ul: UList, li: Li }} />
+        <Content
+          components={{ ul: UList, li: Li, h2: Heading2, h3: Heading3, h4: Heading4, h5: Heading5 }}
+        />
       </div>
     </article>
   </main>
 </ArticlePageRoot>
-
-<style>
-  ._content :global(h2) {
-    @apply py-2 mb-10 mt-20 text-3xl font-normal border-y border-zinc-300;
-    margin-inline: calc(-1 * var(--body-padding-x));
-    padding-inline-start: var(--body-padding-x);
-  }
-
-  ._content :global(h3) {
-    @apply my-10 text-2xl font-normal flex items-center;
-    margin-inline-start: calc(-1 * var(--body-padding-x));
-  }
-  ._content :global(h3::before) {
-    @apply block h-px content-[""] bg-zinc-300;
-    width: calc(var(--body-padding-x) - 0.5ch);
-    margin-inline-end: 0.5ch;
-  }
-  ._content :global(h3::after) {
-    @apply block h-px content-[""] flex-grow bg-zinc-300;
-    margin-inline-start: 0.5ch;
-    margin-inline-end: calc(-1 * var(--body-padding-x));
-  }
-
-  ._content :global(h4) {
-    @apply my-10 text-xl font-normal inline-block border-b-[3px] border-double border-zinc-200;
-    margin-inline-start: calc(-0.5 * var(--body-padding-x));
-    padding-inline: calc(0.5 * var(--body-padding-x));
-  }
-
-  ._content :global(h5) {
-    @apply my-10 text-lg font-normal inline-block border-b-[3px] border-dotted border-zinc-200;
-  }
-</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,6 +2099,13 @@ hast-util-from-parse5@^8.0.0:
     vfile-location "^5.0.0"
     web-namespaces "^2.0.0"
 
+hast-util-heading-rank@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz#2d5c6f2807a7af5c45f74e623498dd6054d2aba8"
+  integrity sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
 hast-util-parse-selector@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
@@ -2212,6 +2219,11 @@ hast-util-whitespace@^3.0.0:
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hast@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hast/-/hast-1.0.0.tgz#50615e6b2b0583e5608bc76c47029722f1e00607"
+  integrity sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==
 
 hastscript@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
## 内容

- 見出しレベルごとにスタイルを当てたheadingタグをコンポーネント化
- そのコンポーネントをtopic各ページのコンテンツに適用
- コンポーネント化された見出しにもidを付与する仕組みを実装

## デザイン

PC
![localhost_4321_pocket-excel-learning_topic_dummy (1)](https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/f6695276-2879-4ff4-bae5-483d480b273a)

Mobile
<img src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/c136c3be-56a9-4137-a65d-3a647cf8042f" width="300" />