### PR TITLE
topicページへの文中リンクコンポーネントを実装し、topicディレクティブとして使えるように

### DIFF
--- a/integration/mdx-directive/component/topic-link.ts
+++ b/integration/mdx-directive/component/topic-link.ts
@@ -1,0 +1,27 @@
+import type { TextDirective } from "mdast-util-directive"
+
+const TAG_NAME = "AutoImportedTopicLink"
+
+const importTopicLinkComponent: Record<string, [string, string][]> = {
+  "./src/components/directive/topic-link.astro": [["default", TAG_NAME]]
+}
+
+const variants = new Set(["topic"])
+
+const isTopicLinkNode = (node: TextDirective) => {
+  return variants.has(node.name)
+}
+
+const parseTopicLinkNode = (node: TextDirective) => {
+  return {
+    name: TAG_NAME,
+    attributes: { id: node.attributes.id },
+    children: node.children
+  }
+}
+
+export const topicLinkText = {
+  import: importTopicLinkComponent,
+  is: isTopicLinkNode,
+  parse: parseTopicLinkNode
+}

--- a/integration/mdx-directive/index.ts
+++ b/integration/mdx-directive/index.ts
@@ -9,10 +9,12 @@ import { closureContainer } from "./component/closure"
 import { popoverExcelFnText } from "./component/popover-excel-fn"
 import { kbdText } from "./component/kbd"
 import { infoContainer } from "./component/info"
+import { topicLinkText } from "./component/topic-link"
 
 export const directiveAutoImport: Record<string, [string, string][]> = {
   ...closureContainer.import,
   ...infoContainer.import,
+  ...topicLinkText.import,
   ...popoverExcelFnText.import,
   ...kbdText.import
 }
@@ -56,6 +58,11 @@ function remarkDirectiveComponent(): unified.Plugin<[], mdast.Root> {
 
         if (kbdText.is(node)) {
           parent.children[index] = makeComponentNode(kbdText.parse(node))
+          return
+        }
+
+        if (topicLinkText.is(node)) {
+          parent.children[index] = makeComponentNode(topicLinkText.parse(node))
           return
         }
       }

--- a/src/components/directive/topic-link.astro
+++ b/src/components/directive/topic-link.astro
@@ -1,0 +1,28 @@
+---
+import { SITE_BASE } from "@/site-config"
+import NoteRefIcon from "@/icons/carbon/notebook-reference.astro"
+import { getEntry } from "astro:content"
+
+interface Props {
+  id: string
+}
+
+const { id } = Astro.props
+
+const entry = await getEntry("topic", id)
+const { color } = entry.data.category
+---
+
+<a
+  href={`${SITE_BASE}/topic/${id}`}
+  class="_link inline-flex no-underline leading-tight p-0.5 rounded border-2 border-dotted"
+>
+  <slot />
+  <NoteRefIcon svgClass="w-2.5 h-2.5 shrink-0 opacity-60" />
+</a>
+
+<style define:vars={{ "category-color": color }}>
+  ._link {
+    border-color: var(--category-color);
+  }
+</style>

--- a/src/icons/carbon/notebook-reference.astro
+++ b/src/icons/carbon/notebook-reference.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  svgClass?: string
+}
+
+const { svgClass } = Astro.props
+---
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="1em"
+  height="1em"
+  class={svgClass}
+  viewBox="2 5 28 24"
+>
+  <path
+    fill="currentColor"
+    d="M4 20v2h3.586L2 27.586L3.414 29L9 23.414V27h2v-7zm15-10h7v2h-7zm0 5h7v2h-7zm0 5h7v2h-7z"
+  >
+  </path><path
+    fill="currentColor"
+    d="M28 5H4a2.002 2.002 0 0 0-2 2v10h2V7h11v20h13a2.002 2.002 0 0 0 2-2V7a2.002 2.002 0 0 0-2-2M17 25V7h11l.002 18Z"
+  >
+  </path>
+</svg>


### PR DESCRIPTION
```mdx
検索文字列の中で:topic[ワイルドカード]{id="wildcard"}を使うことができる。
```

<img width="436" alt="スクリーンショット 2024-03-06 21 50 46" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/3898bc4f-3d2c-4451-a9dd-c511efabb360">
