### PR TITLE
英語用フォントが適用されている部分にもbold指定が効くように修正

### DIFF
--- a/src/layout/head/CommonHead.astro
+++ b/src/layout/head/CommonHead.astro
@@ -5,7 +5,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Ysabeau+Infant:ital,wght@0,300;1,300&family=Zen+Kaku+Gothic+New:wght@400;500&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Ysabeau+Infant:ital,wght@0,1..1000;1,1..1000&family=Zen+Kaku+Gothic+New:wght@400;500&display=swap"
   rel="stylesheet"
 />
 <!-- /fonts -->

--- a/src/pages/fn/index.astro
+++ b/src/pages/fn/index.astro
@@ -24,7 +24,7 @@ const allByCategory = all.reduce(
 <PageRoot>
   <div class="w-full max-w-screen-md mx-auto">
     <Breadcrumb />
-    <Heading tag="h1" class="mb-6 mt-14">Functions</Heading>
+    <Heading tag="h1" class="mb-6 mt-14 font-medium">Functions</Heading>
     {
       Object.entries(allByCategory).map(([category, entry]) => (
         <div class="last:mb-6">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ const pages = import.meta.env.DEV ? _pages : _pages.filter((page) => !page.draft
 
 <PageRoot>
   <div class="max-w-screen-md mx-auto">
-    <Heading tag="h1" class="my-10">{SITE_TITLE}</Heading>
+    <Heading tag="h1" class="my-10 font-medium">{SITE_TITLE}</Heading>
     <ul>
       {
         pages.map((page) => (

--- a/src/pages/question/index.astro
+++ b/src/pages/question/index.astro
@@ -28,7 +28,7 @@ const allByCategory = all.reduce(
 <PageRoot>
   <div class="max-w-screen-md mx-auto">
     <Breadcrumb />
-    <Heading tag="h1" class="mb-6 mt-14">Questions</Heading>
+    <Heading tag="h1" class="mb-6 mt-14 font-medium">Questions</Heading>
     {
       Object.entries(allByCategory).map(([category, questions]) => (
         <div class="last:mb-6">

--- a/src/pages/topic/index.astro
+++ b/src/pages/topic/index.astro
@@ -11,7 +11,7 @@ const all = await getCollection("topic")
 <PageRoot>
   <div class="max-w-screen-md mx-auto">
     <Breadcrumb />
-    <Heading tag="h1" class="mb-10 mt-14">Topics</Heading>
+    <Heading tag="h1" class="mb-10 mt-14 font-medium">Topics</Heading>
     <ul>
       {
         all.map((q) => (


### PR DESCRIPTION
before
<img width="494" alt="スクリーンショット 2024-03-07 19 08 53" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/e53b777e-2a29-499b-bdfe-37a413300b6d">

after
<img width="494" alt="スクリーンショット 2024-03-07 19 09 09" src="https://github.com/tetracalibers/pocket-excel-learning/assets/92695929/dd3390df-bd39-4af7-9e30-cdf202a8951b">
